### PR TITLE
fix(license): remove special quotes from copyright line

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,3 @@
-Copyright (c) 2021 Zero Open Source™ (aka ZeroOpenSource™; “Zero”)
+Copyright (c) 2021 Zero Open Source™ (aka ZeroOpenSource™; Zero)
 
 All rights reserved.


### PR DESCRIPTION
- Removed special quotation marks around "Zero" in the copyright statement  
- Improved compatibility and avoided encoding issues in various tools and environments  
- Ensured the license text is more consistent and easier to process